### PR TITLE
Fix problem selecting items in textadept-curses

### DIFF
--- a/core/buffer.lua
+++ b/core/buffer.lua
@@ -533,7 +533,7 @@ local function _on_keypress(code, shift, ctl, alt, meta)
   if not tr_buf then return end
   local key = key.translate(code, shift, ctl, alt, meta)
 
-  if key and key:match('\n') and
+  if key and key:match('[\r\n]') and
      tr_buf:_on_user_select(tr_buf.current_pos, shift, ctl, alt, meta) then
     return true
   end


### PR DESCRIPTION
The textredux lists don't work for me (I tried textredux.fs.open_file) - I seem to get '\r' instead of '\n' when I press enter to select.  This is the fix I'm using (I later found that this had [previously been reported](https://github.com/rgieseke/textredux/issues/2) and fixed (in a different way), but the fix/workaround was recently removed in [commit 5762bf47c4c79f8d9b66f14221f89962e95df6ca](https://github.com/rgieseke/textredux/commit/5762bf47c4c79f8d9b66f14221f89962e95df6ca).

I don't know if this is any better than the previous fix, but I offer it anyway!

Chris
