### PR TITLE
Fix function calls in fs.save_buffer.

### DIFF
--- a/fs.lua
+++ b/fs.lua
@@ -444,9 +444,9 @@ end
 function M.save_buffer()
   local buffer = _G.buffer
   if buffer.filename then
-    io.save()
+    io.save_file()
   else
-    save_buffer_as()
+    M.save_buffer_as()
   end
 end
 


### PR DESCRIPTION
I wanted to use:

    keys.cs = textredux.fs.save_buffer

to over write the "save as ..." dialog when saving a new buffer, but noticed the function names weren't correct.

Thanks for textredux. I really like it.