### PR TITLE
Allow default mode to be overridden.

### DIFF
--- a/core/buffer.lua
+++ b/core/buffer.lua
@@ -202,7 +202,7 @@ local function set_keys_mode()
   elseif buffer._textredux then
     keys.MODE = buffer._textredux.keys_mode
   else
-    keys.MODE = nil
+    keys.MODE = M.DEFAULT_MODE
   end
 end
 events.connect(events.BUFFER_AFTER_SWITCH, set_keys_mode)


### PR DESCRIPTION
Hi,

I currently use a `vi` mode for Textadept that has a default key mode of `'normal'` rather than `nil` (`'insert'`). With this diff below, I can override the default mode so I am put in `'normal'` mode rather than `nil` ('`insert'`) mode by using `textredux.core.buffer.DEFAULT_MODE = 'normal'` in my `init.lua`. I notice this in particular on file open.

Please let me know what you think.

Thanks!
Chad