### PR TITLE
Update buffer.dirty to buffer.modify

### DIFF
--- a/buffer_list.lua
+++ b/buffer_list.lua
@@ -73,7 +73,7 @@ local function get_buffer_items()
   local items = {}
   for _, buffer in ipairs(buffer_source()) do
     if M.list.buffer.target ~= buffer then
-      local modified = buffer.dirty and '*' or ''
+      local modified = buffer.modify and '*' or ''
       items[#items + 1] = {
         buffer_title(buffer) .. modified,
         buffer_directory(buffer),


### PR DESCRIPTION
Buffer names should display a '*' next to their name if they have been changed. TA renamed the 'dirty' property to 'modify' a long time ago and this was never updated in TR.