### PR TITLE
Fix buffer line number background color

### DIFF
--- a/core/buffer.lua
+++ b/core/buffer.lua
@@ -478,7 +478,6 @@ function reduxbuffer:_create_target()
   target.wrap_mode = target.WRAP_NONE
   target.margin_width_n[1] = not CURSES and target.margin_width_n[0] + 4 or 1
   target.margin_width_n[0] = 0
-  target.style_back[33] = target.caret_line_back
   target:set_save_point()
   target.undo_collection = false
   self.target = target


### PR DESCRIPTION
The buffer line number margin background color is different from the buffer background color. This "fixes" itself after e.g. deleting an item from the buffer list.
IMO it's better to always have the same style and not just after arbitrary changes to the list.