### PR TITLE
Force-create (or open if it exists) a search query that otherwise fuzzy-matches an existing entry.

### DIFF
--- a/fs.lua
+++ b/fs.lua
@@ -402,6 +402,23 @@ local function create_list(directory, filter, depth, max_files)
       end
     end
   end
+  list.keys["ctrl+\n"] = function ()
+	local search = list:get_current_search()
+	local found = false
+
+	for _, item in ipairs(list.buffer.data.matching_items) do
+		if item[1] == search then
+			found = true
+			break
+		end
+	end
+
+	if found then
+		list.buffer._on_user_select(list.buffer, list.buffer.current_pos)
+	else
+		list:on_new_selection(search)
+	end
+  end
 
   data.directory = directory
   data.filter = filter


### PR DESCRIPTION
For example, if I wish to create a file 'set.lua', but already have a file name 'settings.lua', the latter will be matched, forcing me to open that file, instead of letting me create the new file I want. Here, I have some code that binds "ctrl+n" to a "force-create" action; that is, if 'setttings.lua' is matched, I can still force the creation of the flie 'set.lua' with "ctrl+n". As a foolproof measure,
if "ctrl+n" is used on an existing entry, that entry is simply opened (instead of being overwritten by a call to 'io.write').

I'm using this binding, and it's pretty handy :)

Hope this looks OK. My fear is that it's too _specific_ of a solution (that is, it doesn't span all of Textredux), but hopefully it's a 
start.