### PR TITLE
Add guard to toggle filter only with not-nil char

### DIFF
--- a/core/buffer.lua
+++ b/core/buffer.lua
@@ -217,7 +217,10 @@ events.connect(events.CHAR_ADDED, function(code)
   if _textredux.on_char_added then
     local char = code < 256 and (not CURSES or (code ~= 7 and code ~= 13)) and
         string.char(code) or keys.KEYSYMS[code]
-    _textredux.on_char_added(char)
+
+    if char ~= nil then
+      _textredux.on_char_added(char)
+    end
   end
 end)
 


### PR DESCRIPTION
If char is not registered in Textadept (e.g. russian by default aren't #5) the error breaks the workflow - especially when you work in several views (it changes focus to other view).

---
P.S.
Could you please verify that I have not broke anything? Maybe we need to add this check to other place?