### PR TITLE
Change backspace behavior in lists to delete only words

### DIFF
--- a/core/list.lua
+++ b/core/list.lua
@@ -355,10 +355,15 @@ function list:_create_buffer()
     if search then self.set_current_search(self, search:sub(1, #search - 1)) end
   end
 
-  local clear_search = function() self:set_current_search('') end
-  listbuffer.keys['ctrl+\b'] = clear_search
-  listbuffer.keys['alt+\b'] = clear_search
-  listbuffer.keys['cmd+\b'] = clear_search
+  local search_delete_word = function()
+    local search = self:get_current_search()
+    if search then
+      self:set_current_search(search:gsub('%s*$', ''):match('^(.*%s)%S*$'))
+    end
+  end
+  listbuffer.keys['ctrl+\b'] = search_delete_word
+  listbuffer.keys['alt+\b'] = search_delete_word
+  listbuffer.keys['cmd+\b'] = search_delete_word
 
   local key_wrapper = function(t, k, v)
     if type(v) == 'function' then


### PR DESCRIPTION
The usual behavior for <kbd>CTRL</kbd>+<kbd>Backspace</kbd> is to delete the word left of the cursor. In TR this currently deletes the entire search query. This patch changes the behavior to the "normal" one.  
The old way of deleting everything can still be achieved by using <kbd>ALT</kbd>+<kbd>Backspace</kbd>