### PR TITLE
Ensure 'select' keybinds are the same in lists

### DIFF
--- a/fs.lua
+++ b/fs.lua
@@ -433,7 +433,7 @@ local function create_list(directory, filter, depth, max_files)
       end
     end
   end
-  list.keys["ctrl+\n"] = function ()
+  list.keys["right"] = function()
     local search = list:get_current_search()
     if not search then return end
     local found = false


### PR DESCRIPTION
Right now there are two different keybinds to trigger special select behavior in lists. To avoid confusion it might be best if these were the same.