### PR TITLE
Update ui.dialogs.* to match API changes

### DIFF
--- a/core/filteredlist.lua
+++ b/core/filteredlist.lua
@@ -3,7 +3,7 @@
 -- License: MIT (see LICENSE)
 
 --[[--
-Filtered list wrapper, hijacking `ui.dialogs.filteredlist`.
+Filtered list wrapper, hijacking `ui.dialogs.list`.
 
 @module textredux.core.filteredlist
 ]]
@@ -12,7 +12,7 @@ local list = require 'textredux.core.list'
 
 local M = {}
 
-local ui_filteredlist = ui.dialogs.filteredlist
+local ui_filteredlist = ui.dialogs.list
 local current_coroutine
 
 local function convert_multi_column_table(nr_columns, items)
@@ -33,7 +33,7 @@ local function index_of(element, table)
   end
 end
 
-ui.dialogs.filteredlist = function(options)
+ui.dialogs.list = function(options)
   if not current_coroutine then
     return ui_filteredlist(options)
   end

--- a/fs.lua
+++ b/fs.lua
@@ -306,7 +306,7 @@ end
 
 local function open_selected_file(path, exists, list)
   if not exists then
-    local retval = ui.dialogs.msgbox
+    local retval = ui.dialogs.message
     {
       title = 'Create new file',
       text = path .. "\ndoes not exist, do you want to create it?",


### PR DESCRIPTION
See https://orbitalquark.github.io/textadept/api.html#ui.dialogs.

This updates the names of ui.dialogs according to the new API. Wrapped lists now show up properly again but do NOT work yet. I haven't had much time to look into it but I suspect list API changes prevent them from fully working.

Maybe something to do with these lines:

https://github.com/rgieseke/textredux/blob/5abf1ac4e69119ab74247186d7ed4bbfbc6bf50b/core/filteredlist.lua#L52

https://github.com/rgieseke/textredux/blob/5abf1ac4e69119ab74247186d7ed4bbfbc6bf50b/core/filteredlist.lua#L54

